### PR TITLE
Removing path validation to allow alternatives families

### DIFF
--- a/lib/puppet/type/alternatives.rb
+++ b/lib/puppet/type/alternatives.rb
@@ -7,10 +7,6 @@ Puppet::Type.newtype(:alternatives) do
 
   newproperty(:path) do
     desc 'The path of the desired source for the given alternative'
-
-    validate do |path|
-      raise ArgumentError, 'path must be a fully qualified path' unless absolute_path? path
-    end
   end
 
   newproperty(:mode, required_features: [:mode]) do


### PR DESCRIPTION
Working on #71

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Removes the validation for the `path` parameter, to allow use of alternatives' "families"
My "Fix" below is more of a "workaround", I think.

#### This Pull Request (PR) fixes the following issues
Fixes #71
